### PR TITLE
Remove stale manager assignment test

### DIFF
--- a/test/controllers/manager/assignment_controller_test.rb
+++ b/test/controllers/manager/assignment_controller_test.rb
@@ -1,8 +1,0 @@
-require "test_helper"
-
-class Manager::AssignmentControllerTest < ActionDispatch::IntegrationTest
-  test "should get index" do
-    get manager_assignment_index_url
-    assert_response :success
-  end
-end


### PR DESCRIPTION
## Summary
- remove unused `assignment_controller_test`

## Testing
- `ruby bin/rails test` *(fails: Could not find rails-7.1.5.1)*

------
https://chatgpt.com/codex/tasks/task_e_684826fdc6908327b06228a9c82065c7