### PR TITLE
Fix shift request cleanup after assignment

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -12,13 +12,14 @@ class Project < ApplicationRecord
     needed = required_number - shift_assignments.count
     return if needed <= 0
 
-    # 希望提出順に limit だけループして確定を作成
-    shift_requests.limit(needed).each do |req|
+    requests = shift_requests.limit(needed)
+
+    requests.each do |req|
       shift_assignments.create!(user: req.user)
     end
 
-    # （任意）既に割り当て済みの shift_requests は削除しておく
-    shift_requests.where(id: shift_assignments.pluck(:id)).destroy_all
+    # 割り当て完了後、対応する申請を削除
+    requests.destroy_all
   end
 
 end

--- a/test/fixtures/projects.yml
+++ b/test/fixtures/projects.yml
@@ -3,9 +3,9 @@
 one:
   title: MyString
   work_date: 2025-05-03
-  required_workers: 1
+  required_number: 1
 
 two:
   title: MyString
   work_date: 2025-05-03
-  required_workers: 1
+  required_number: 1

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -1,7 +1,16 @@
 require "test_helper"
 
 class ProjectTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "complete_shift_assignments removes requests" do
+    project = Project.create!(title: "Test", work_date: Date.today, required_number: 1)
+    user = User.create!(email: "user@example.com", password: "password")
+    ShiftRequest.create!(user: user, project: project)
+
+    assert_difference ["ShiftAssignment.count", "ShiftRequest.count"], [1, -1] do
+      project.complete_shift_assignments!
+    end
+
+    assert_equal 0, project.shift_requests.count
+    assert_equal user, project.shift_assignments.last.user
+  end
 end


### PR DESCRIPTION
## Summary
- fix `complete_shift_assignments!` so processed requests are removed
- update fixtures for new `required_number` field
- add test verifying requests are deleted when assignments are created

## Testing
- `bundle exec rake test TEST=test/models/project_test.rb --verbose` *(fails: Could not find rails-7.1.5.1 ...)*

------
https://chatgpt.com/codex/tasks/task_e_68482718533c832786e5852c584a2cc8