### PR TITLE
Fix comment for confirmed routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,7 +44,7 @@ Rails.application.routes.draw do
   end
 
   # ──────────────────────────────────────
-  # 2. 確定シフト一覧＆更新 (ConfirmationsController)
+  # 2. 確定シフト一覧＆更新 (ConfirmedController)
   #    - パスだけ confirmed にマッピング
   #    - URL: /manager/confirmed
   # ──────────────────────────────────────


### PR DESCRIPTION
## Summary
- clarify controller name in routes comments

## Testing
- `bundle exec rake test` *(fails: Could not find gems)*

------
https://chatgpt.com/codex/tasks/task_e_68482708dc7c83279bb0d1d1da177561