### PR TITLE
Remove shift requests for assigned users

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -18,7 +18,7 @@ class Project < ApplicationRecord
     end
 
     # （任意）既に割り当て済みの shift_requests は削除しておく
-    shift_requests.where(id: shift_assignments.pluck(:id)).destroy_all
+    shift_requests.where(user_id: shift_assignments.pluck(:user_id)).destroy_all
   end
 
 end


### PR DESCRIPTION
## Summary
- delete shift requests for users already assigned to a project

## Testing
- `bundle exec rake test` *(fails: Your Ruby version is 3.4.4, but your Gemfile specified 3.3.8)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe7dcffe8832782f57f77c25a82eb