### PR TITLE
Add cream background to calendar section

### DIFF
--- a/app/assets/stylesheets/staff/style.css
+++ b/app/assets/stylesheets/staff/style.css
@@ -89,6 +89,13 @@
 /* -------------------------------------------------
 　calender
 ------------------------------------------------- */
+.calendar-container {
+  background-color: #fffdf7;
+  padding: 1.5rem;
+  border-radius: 12px;
+  margin-bottom: 2rem;
+}
+
 .calendar {
   margin: 30px auto;
 }

--- a/app/views/staff/index.html.erb
+++ b/app/views/staff/index.html.erb
@@ -21,8 +21,10 @@
           
             <!--カレンダー画面 --------------------------------->
             <div class="swiper-slide">
-              <%= render partial: "staff/calendar/calendar_view",
-                          locals: { calendar_days: @calendar_days,projects_by_date: @projects_by_date } %>
+              <div class="calendar-container">
+                <%= render partial: "staff/calendar/calendar_view",
+                            locals: { calendar_days: @calendar_days,projects_by_date: @projects_by_date } %>
+              </div>
             </div>
           
             <!--マイシフト画面 --------------------------------->


### PR DESCRIPTION
## Summary
- Wrap calendar portion in `calendar-container`
- Add cream background and padding to clarify separation from other sections

## Testing
- `bundle exec rails test` *(fails: command not found: rails)*
- `bundle install` *(fails: Your Ruby version is 3.4.4, but your Gemfile specified 3.4.5)*

------
https://chatgpt.com/codex/tasks/task_e_68c527aff99c8327ad9cfd7d7c470579